### PR TITLE
Index to distinguish EndPoints like in yojimbo

### DIFF
--- a/ReliableNetcode/ReliableEndpoint.cs
+++ b/ReliableNetcode/ReliableEndpoint.cs
@@ -43,39 +43,39 @@ namespace ReliableNetcode
 		/// </summary>
 		public Action<byte[], int> ReceiveCallback;
 
-        /// <summary>
-        /// Approximate round-trip-time
-        /// </summary>
-        public float RTT => _reliableChannel.RTT;
+		/// <summary>
+		/// Approximate round-trip-time
+		/// </summary>
+		public float RTT => _reliableChannel.RTT;
 
-        /// <summary>
-        /// Approximate packet loss
-        /// </summary>
-        public float PacketLoss => _reliableChannel.PacketLoss;
+		/// <summary>
+		/// Approximate packet loss
+		/// </summary>
+		public float PacketLoss => _reliableChannel.PacketLoss;
 
-        /// <summary>
-        /// Approximate send bandwidth
-        /// </summary>
-        public float SentBandwidthKBPS => _reliableChannel.SentBandwidthKBPS;
+		/// <summary>
+		/// Approximate send bandwidth
+		/// </summary>
+		public float SentBandwidthKBPS => _reliableChannel.SentBandwidthKBPS;
 
-        /// <summary>
-        /// Approximate received bandwidth
-        /// </summary>
-        public float ReceivedBandwidthKBPS => _reliableChannel.ReceivedBandwidthKBPS;
+		/// <summary>
+		/// Approximate received bandwidth
+		/// </summary>
+		public float ReceivedBandwidthKBPS => _reliableChannel.ReceivedBandwidthKBPS;
 
-        private MessageChannel[] messageChannels;
+		private MessageChannel[] messageChannels;
 		private double time = 0.0;
 
-        // the reliable channel
-        private ReliableMessageChannel _reliableChannel;
-        
+		// the reliable channel
+		private ReliableMessageChannel _reliableChannel;
+
 		public ReliableEndpoint()
 		{
 			time = DateTime.Now.GetTotalSeconds();
 
-            _reliableChannel = new ReliableMessageChannel() { TransmitCallback = this.transmitMessage, ReceiveCallback = this.receiveMessage };
-            
-            messageChannels = new MessageChannel[]
+			_reliableChannel = new ReliableMessageChannel() { TransmitCallback = this.transmitMessage, ReceiveCallback = this.receiveMessage };
+
+			messageChannels = new MessageChannel[]
 			{
 				_reliableChannel,
 				new UnreliableMessageChannel() { TransmitCallback = this.transmitMessage, ReceiveCallback = this.receiveMessage },
@@ -136,7 +136,7 @@ namespace ReliableNetcode
 		{
 			messageChannels[(int)qos].SendMessage(buffer, bufferLength);
 		}
-		
+
 		protected void receiveMessage(byte[] buffer, int length)
 		{
 			ReceiveCallback(buffer, length);

--- a/ReliableNetcode/ReliableEndpoint.cs
+++ b/ReliableNetcode/ReliableEndpoint.cs
@@ -43,6 +43,11 @@ namespace ReliableNetcode
 		/// </summary>
 		public Action<byte[], int> ReceiveCallback;
 
+		// Index, buffer, bufferLength
+		public Action<uint, byte[], int> TransmitExtendedCallback;
+		public Action<uint, byte[], int> ReceiveExtendedCallback;
+		public uint Index = uint.MaxValue;
+
 		/// <summary>
 		/// Approximate round-trip-time
 		/// </summary>
@@ -81,6 +86,11 @@ namespace ReliableNetcode
 				new UnreliableMessageChannel() { TransmitCallback = this.transmitMessage, ReceiveCallback = this.receiveMessage },
 				new UnreliableOrderedMessageChannel() { TransmitCallback = this.transmitMessage, ReceiveCallback = this.receiveMessage },
 			};
+		}
+
+		public ReliableEndpoint(uint index) : this()
+		{
+			Index = index;
 		}
 
 		/// <summary>
@@ -139,12 +149,20 @@ namespace ReliableNetcode
 
 		protected void receiveMessage(byte[] buffer, int length)
 		{
-			ReceiveCallback(buffer, length);
+			if (ReceiveCallback != null)
+				ReceiveCallback(buffer, length);
+
+			if (ReceiveExtendedCallback != null)
+				ReceiveExtendedCallback(Index, buffer, length);
 		}
 
 		protected void transmitMessage(byte[] buffer, int length)
 		{
-			TransmitCallback(buffer, length);
+			if (TransmitCallback != null)
+				TransmitCallback(buffer, length);
+
+			if (TransmitExtendedCallback != null)
+				TransmitExtendedCallback(Index, buffer, length);
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/networkprotocol/yojimbo/blob/c1f06f18d61003e02c075e8cfc0cf0f7ec671c31/yojimbo.cpp#L3512

Index is very useful for server to distinguish EndPoints. The main idea:
```
private void Server_OnClientConnected(RemoteClient client)
{
	uint index = client.ClientIndex;
	NetworkingPlayer player = new NetworkingPlayer(client);
	if (!connectedPlayers.ContainsKey(index))
		connectedPlayers.Add(index, player);

	ReliableEndpoint reliableEndpoint = new ReliableEndpoint(index);
	reliableEndpoint.ReceiveExtendedCallback = ReliableReceiveCallback;
	reliableEndpoint.TransmitExtendedCallback = ReliableTransmitCallback;
	playerEndpoints[index] = reliableEndpoint;
}

private void ReliableTransmitCallback(uint index, byte[] buffer, int bufferLength)
{
	var player = GetPlayerByIndex(index);
	if (player != null)
		netcodeServer.SendPayload(player.RemoteClient, buffer, bufferLength);
}

private void ReliableReceiveCallback(uint index, byte[] buffer, int bufferLength)
{
	var player = GetPlayerByIndex(index);
	testRPC.Receive(player, buffer, bufferLength);
}

```
This helps to generalize and simplify rx/tx stuff for different clients on server.

p.s. It would be nice to have a coding conventions, because currently it's unclear (for example tabs or spaces). Contributors should stick with those conventions and use them consistently.